### PR TITLE
Add building gdino into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ RUN python -m pip install --upgrade pip setuptools wheel numpy
 # Install segment_anything package in editable mode
 RUN python -m pip install -e .
 
+# Install grounding dino 
+RUN python -m pip install --no-build-isolation -e grounding_dino


### PR DESCRIPTION
Running `grounded_sam2_local_demo.py` inside the docker container created using provided `Dockerfile` leads to the `name '_C' is not defined` error, related to `grounding_dino` package.
I was able to solve it by making an additional step in the `Dockerfile`, just like it's mentioned in README.
If some other users encounter the same issue, this could be the fix. 