### PR TITLE
fix:fixed interruptions when there is no mask result for the current …

### DIFF
--- a/utils/common_utils.py
+++ b/utils/common_utils.py
@@ -48,6 +48,10 @@ class CommonUtils:
                     object_mask = (mask == uid)
                     all_object_masks.append(object_mask[None])
             
+            if len(all_object_masks) == 0:
+                output_image_path = os.path.join(output_path, raw_image_name)
+                cv2.imwrite(output_image_path, image)
+                continue
             # get n masks: (n, h, w)
             all_object_masks = np.concatenate(all_object_masks, axis=0)
             


### PR DESCRIPTION

## Pre-Checklist
Please complete **_ALL_** items in the following checklist.

- [x] I have read through the [CONTRIBUTING.md](https://github.com/IDEA-Research/Grounded-SAM-2/blob/be1fa537bbfe537d62c6f1f83917a342ce18a1f0/CONTRIBUTING.md) documentation.
- [x] My code has the necessary comments and documentation(if needed).
- [x] I have added relevant tests. 

## Description
When performing video inference, if a frame does not have a mask result, it cannot be merged to complete the final result:

> File "./Projects/Grounded-SAM-2_wjh/utils/common_utils.py", line 52, in draw_masks_and_box_with_supervision
> all_object_masks = np.concatenate(all_object_masks, axis=0)
> ValueError: need at least one array to concatenate

## Test
![image](https://github.com/user-attachments/assets/22ae97a2-5b50-40f9-bcd5-75eb55b9b8f0)

