### PR TITLE
Pin setuptools to fix Docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /home/appuser/Grounded-SAM-2
 
 
 # Install essential Python packages
-RUN python -m pip install --upgrade pip setuptools wheel numpy \
+RUN python -m pip install --upgrade pip "setuptools>=62.3.0,<75.9" wheel numpy \
     opencv-python transformers supervision pycocotools addict yapf timm
 
 # Install segment_anything package in editable mode


### PR DESCRIPTION
See [this Issue](https://github.com/IDEA-Research/Grounded-SAM-2/issues/98). The Dockerfile is broken since a recent update to setuptools and pip, which disables the option to load packages from within setup.py. See [this issue](https://github.com/facebookresearch/sam2/issues/611#issuecomment-2741690522) in the original sam2 repo, and [this PR](https://github.com/IDEA-Research/Grounded-SAM-2/pull/91) in this repo.