### PR TITLE
fix: use initialize_config_dir to support custom Hydra config roots and prevent reinitialization errors

### DIFF
--- a/grounded_sam2_local_demo.py
+++ b/grounded_sam2_local_demo.py
@@ -17,7 +17,7 @@ Hyper parameters
 TEXT_PROMPT = "car. tire."
 IMG_PATH = "notebooks/images/truck.jpg"
 SAM2_CHECKPOINT = "./checkpoints/sam2.1_hiera_large.pt"
-SAM2_MODEL_CONFIG = "configs/sam2.1/sam2.1_hiera_l.yaml"
+SAM2_MODEL_CONFIG = "./sam2/configs/sam2.1/sam2.1_hiera_l.yaml"
 GROUNDING_DINO_CONFIG = "grounding_dino/groundingdino/config/GroundingDINO_SwinT_OGC.py"
 GROUNDING_DINO_CHECKPOINT = "gdino_checkpoints/groundingdino_swint_ogc.pth"
 BOX_THRESHOLD = 0.35


### PR DESCRIPTION
This patch replaces the direct call to `compose()` with a safer and more flexible Hydra pattern using `initialize_config_dir`. It resolves issues encountered when:

- Running without `hydra.main()` (e.g., in scripts or notebooks)
- Using custom config directories not in Hydra's default search path
- Reusing Hydra within the same Python process (caused GlobalHydra reinitialization errors)

The fix:
- Explicitly initializes Hydra with the given `config_root`
- Clears existing Hydra state before initialization to prevent errors
- Adds logging and error handling for better debuggability

This makes the `build_sam2()` function robust across different environments and ensures compatibility with Hydra ≥ 1.3.2.
