### PR TITLE
Fix demos for CPU inference

### DIFF
--- a/grounded_sam2_hf_model_demo.py
+++ b/grounded_sam2_hf_model_demo.py
@@ -44,7 +44,7 @@ OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 # use bfloat16
 torch.autocast(device_type=DEVICE, dtype=torch.bfloat16).__enter__()
 
-if torch.cuda.get_device_properties(0).major >= 8:
+if torch.cuda.is_available() and torch.cuda.get_device_properties(0).major >= 8:
     # turn on tfloat32 for Ampere GPUs (https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices)
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True

--- a/grounded_sam2_local_demo.py
+++ b/grounded_sam2_local_demo.py
@@ -61,6 +61,7 @@ boxes, confidences, labels = predict(
     caption=text,
     box_threshold=BOX_THRESHOLD,
     text_threshold=TEXT_THRESHOLD,
+    device=DEVICE
 )
 
 # process the box prompt for SAM 2
@@ -70,9 +71,9 @@ input_boxes = box_convert(boxes=boxes, in_fmt="cxcywh", out_fmt="xyxy").numpy()
 
 
 # FIXME: figure how does this influence the G-DINO model
-torch.autocast(device_type="cuda", dtype=torch.bfloat16).__enter__()
+torch.autocast(device_type=DEVICE, dtype=torch.bfloat16).__enter__()
 
-if torch.cuda.get_device_properties(0).major >= 8:
+if torch.cuda.is_available() and torch.cuda.get_device_properties(0).major >= 8:
     # turn on tfloat32 for Ampere GPUs (https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices)
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True


### PR DESCRIPTION
I tried running both the HF and the local demo on a computer without a GPU, and ran into `AssertionError: Torch not compiled with CUDA enabled`

These were the problem areas I fixed:
* HF demo
  * `torch.cuda.get_device_properties` will fail if `torch.cuda.is_available()` is `False`
* Local demo  
  * `torch.cuda.get_device_properties` will fail if `torch.cuda.is_available()` is `False`
  * `torch.autocast` did not have the correct device passed in
  * The Grounding DINO `predict(` did not pass in a value for the `device` argument, which is `cuda` by default